### PR TITLE
fix readme: abao should be installed globally using npm install -g

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 [Node.js][] and [NPM][] is required.
 
-    $ npm install abao
+    $ npm install -g abao
 
 [Node.js]: https://npmjs.org/
 [NPM]: https://npmjs.org/


### PR DESCRIPTION
npm install **-g** 

Some users won't figure it out on their own ;)
http://forums.raml.org/t/abao-is-launched-an-automated-api-testing-tool-for-raml/494/6
