### PR TITLE
add source-map support

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -24,6 +24,8 @@ module.exports = (grunt) ->
 
     coffee:
       compile:
+        options:
+            sourceMap: true
         expand: true,
         flatten: true,
         src: ['src/*.coffee'],

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "proxyquire": "^1.3.1",
     "raml-parser": "^0.8.10",
     "request": "^2.53.0",
+    "source-map-support": "^0.3.2",
     "underscore": "^1.8.2"
   }
 }

--- a/src/abao.coffee
+++ b/src/abao.coffee
@@ -1,3 +1,4 @@
+sms = require("source-map-support").install({handleUncaughtExceptions: false})
 raml = require 'raml-parser'
 async = require 'async'
 chai = require 'chai'


### PR DESCRIPTION
This adds source-map support to abao so that errors from within abao (for example because of a developer mistake during development) result in stack traces with line numbers that reference the coffee source file(s) instead of the javascript file(s).

For example, here's an example from before (encountered while working on something else):
```
     TypeError: undefined is not a function
    at <pth>/abao/lib/hooks.js:82:16
    at test/volume_hooks.js:118:12
    at <pth>/abao/lib/hooks.js:82:16
    at Hooks.runBefore (<pth>/abao/lib/hooks.js:81:20)
    at Hooks.runBefore (<pth>/abao/lib/hooks.js:3:59)
    at Object.suite.beforeAll._.bind.hooks (<pth>/abao/lib/test-runner.js:37:29)
```

And after:
```
     TypeError: undefined is not a function
      at <pth>/abao/src/hooks.coffee:50:7
      at test/volume_hooks.coffee:111:12
      at <pth>/abao/src/hooks.coffee:50:7
      at Hooks.runBefore (<pth>/abao/src/hooks.coffee:49:11)
      at Hooks.runBefore (<pth>/abao/src/hooks.coffee:1:1)
      at Object.suite.beforeAll._.bind.hooks (<pth>/abao/src/test-runner.coffee:32:16)
```
