### PR TITLE
add beforeEach and afterEach

### DIFF
--- a/src/hooks.coffee
+++ b/src/hooks.coffee
@@ -7,6 +7,8 @@ class Hooks
     @afterHooks = {}
     @beforeAllHooks = []
     @afterAllHooks = []
+    @beforeEachHooks = []
+    @afterEachHooks = []
 
   before: (name, hook) =>
     @addHook(@beforeHooks, name, hook)
@@ -19,6 +21,12 @@ class Hooks
 
   afterAll: (hook) =>
     @afterAllHooks.push hook
+
+  beforeEach: (hook) =>
+    @beforeEachHooks.push(hook)
+
+  afterEach: (hook) =>
+    @afterEachHooks.push(hook)
 
   addHook: (hooks, name, hook) =>
     if hooks[name]
@@ -35,16 +43,18 @@ class Hooks
       callback(err)
 
   runBefore: (test, callback) =>
-    return callback() unless @beforeHooks[test.name]
+    return callback() unless (@beforeHooks[test.name] or @beforeEachHooks)
 
-    async.eachSeries @beforeHooks[test.name], (hook, callback) ->
+    hooks = @beforeEachHooks.concat(@beforeHooks[test.name] ? [])
+    async.eachSeries hooks, (hook, callback) ->
       hook test, callback
     , callback
 
   runAfter: (test, callback) =>
-    return callback() unless @afterHooks[test.name]
+    return callback() unless (@afterHooks[test.name] or @afterEachHooks)
 
-    async.eachSeries @afterHooks[test.name], (hook, callback) ->
+    hooks = (@afterHooks[test.name] ? []).concat(@afterEachHooks)
+    async.eachSeries hooks, (hook, callback) ->
       hook test, callback
     , callback
 

--- a/test/unit/hooks-test.coffee
+++ b/test/unit/hooks-test.coffee
@@ -65,6 +65,96 @@ describe 'Hooks', () ->
       hooks.runAfterAll (done) ->
         testDone()
 
+  describe 'when adding beforeEach hooks', () ->
+
+    afterEach () ->
+      hooks.beforeEachHooks = []
+      hooks.beforeHooks = {}
+
+    it 'should add to hook list', () ->
+      hooks.beforeEach () ->
+      assert.lengthOf hooks.beforeEachHooks, 1
+
+    it 'should invoke registered callbacks', (testDone) ->
+      before_called = false
+      before_each_called = false
+      test_name = "before_test"
+      hooks.before test_name, (test, done) ->
+        assert.equal test.name, test_name
+        before_called = true
+        assert.isTrue before_each_called,
+            "before_hook should be called after before_each"
+        done()
+
+      hooks.beforeEach (test, done) ->
+        assert.equal test.name, test_name
+        before_each_called = true
+        assert.isFalse before_called,
+            "before_each should be called before before_hook"
+        done()
+
+      hooks.runBefore {name: test_name}, () ->
+        assert.isTrue before_each_called, "before_each should have been called"
+        assert.isTrue before_called, "before_hook should have been called"
+        testDone()
+
+    it 'should work without test specific before', (testDone) ->
+      before_each_called = false
+      test_name = "before_test"
+      hooks.beforeEach (test, done) ->
+        assert.equal test.name, test_name
+        before_each_called = true
+        done()
+
+      hooks.runBefore {name: test_name}, () ->
+        assert.isTrue before_each_called, "before_each should have been called"
+        testDone()
+
+  describe 'when adding afterEach hooks', () ->
+
+    afterEach () ->
+      hooks.afterEachHooks = []
+      hooks.afterHooks = {}
+
+    it 'should add to hook list', () ->
+      hooks.afterEach () ->
+      assert.lengthOf hooks.afterEachHooks, 1
+
+    it 'should invoke registered callbacks', (testDone) ->
+      after_called = false
+      after_each_called = false
+      test_name = "after_test"
+      hooks.after test_name, (test, done) ->
+        assert.equal test.name, test_name
+        after_called = true
+        assert.isFalse after_each_called,
+            "after_hook should be called before after_each"
+        done()
+
+      hooks.afterEach (test, done) ->
+        assert.equal test.name, test_name
+        after_each_called = true
+        assert.isTrue after_called,
+            "after_each should be called after after_hook"
+        done()
+
+      hooks.runAfter {name: test_name}, () ->
+        assert.isTrue after_each_called, "after_each should have been called"
+        assert.isTrue after_called, "after_hook should have been called"
+        testDone()
+
+    it 'should work without test specific after', (testDone) ->
+      after_each_called = false
+      test_name = "after_test"
+      hooks.afterEach (test, done) ->
+        assert.equal test.name, test_name
+        after_each_called = true
+        done()
+
+      hooks.runAfter {name: test_name}, () ->
+        assert.isTrue after_each_called, "after_each should have been called"
+        testDone()
+
   describe 'when check has name', () ->
 
     it 'should return true if in before hooks', ->


### PR DESCRIPTION
This adds support for the beforeEach and afterEach test setup functions. They mirror the ones that exist in mocha. `beforeEach` functions are run before any test specific `before` functions. `afterEach` functions are run after any test specific `after` functions. I think this also provides a fix for issue #20. It doesn't expose it in `beforeAll`, but it provides the necessary functionality (I think).