### PR TITLE
add 'test' support, allows content of responses to be checked

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ afterAll (done) ->
 
 If `beforeAll`, `afterAll`, `before` and `after` are called multiple times, the callbacks are executed serially in the order they were called.
 
+**Abao** provides hook to allow the content of the response to be
+checked within the test:
+
+```coffee
+{test} = require 'hooks'
+
+test 'GET /machines -> 200', (response, body, done) ->
+    assert.deepEqual(JSON.parse(body), ["machine1", "machine2"])
+    assert.equal(headers["content-type"], 'application/json; charset=utf-8')
+	return done()
+```
+
 ### test.request
 
 - `server` - Server address, provided from CLI.

--- a/src/abao.coffee
+++ b/src/abao.coffee
@@ -23,6 +23,11 @@ class Abao
     hooks = @hooks
 
     async.waterfall [
+      # Parse hooks
+      (callback) ->
+        addHooks hooks, config.options.hookfiles
+        callback()
+      ,
       # Load RAML
       (callback) ->
         raml.loadFile(config.ramlPath).then (raml) ->
@@ -31,12 +36,7 @@ class Abao
       ,
       # Parse tests from RAML
       (raml, callback) ->
-        addTests raml, tests, callback
-      ,
-      # Parse hooks
-      (callback) ->
-        addHooks hooks, config.options.hookfiles
-        callback()
+        addTests raml, tests, hooks, callback
       ,
       # Run tests
       (callback) ->

--- a/src/add-hooks.coffee
+++ b/src/add-hooks.coffee
@@ -3,7 +3,6 @@ path = require 'path'
 require 'coffee-script/register'
 proxyquire = require('proxyquire').noCallThru()
 glob = require 'glob'
-async = require 'async'
 
 
 addHooks = (hooks, pattern) ->

--- a/src/add-tests.coffee
+++ b/src/add-tests.coffee
@@ -22,10 +22,10 @@ parseHeaders = (raml) ->
 
   headers
 
-# addTests(raml, tests, [parent], callback)
-addTests = (raml, tests, parent, callback) ->
+# addTests(raml, tests, hooks, [parent], callback)
+addTests = (raml, tests, hooks, parent, callback) ->
 
-  # Handle 3th optional param
+  # Handle 4th optional param
   if _.isFunction(parent)
     callback = parent
     parent = null
@@ -57,12 +57,11 @@ addTests = (raml, tests, parent, callback) ->
       # Iterate response status
       for status, res of api.responses
 
-        # Append new test to tests
-        test = new Test
-        tests.push test
+        testName = "#{method} #{path} -> #{status}"
 
-        # Update test
-        test.name = "#{method} #{path} -> #{status}"
+        # Append new test to tests
+        test = new Test(testName, hooks.contentTests[testName])
+        tests.push test
 
         # Update test.request
         test.request.path = path
@@ -87,7 +86,7 @@ addTests = (raml, tests, parent, callback) ->
       return callback(err) if err
 
       # Recursive
-      addTests resource, tests, {path, params}, callback
+      addTests resource, tests, hooks, {path, params}, callback
   , callback
 
 

--- a/src/hooks.coffee
+++ b/src/hooks.coffee
@@ -9,6 +9,7 @@ class Hooks
     @afterAllHooks = []
     @beforeEachHooks = []
     @afterEachHooks = []
+    @contentTests = {}
 
   before: (name, hook) =>
     @addHook(@beforeHooks, name, hook)
@@ -33,6 +34,11 @@ class Hooks
       hooks[name].push hook
     else
       hooks[name] = [hook]
+
+  test: (name, hook) =>
+    if @contentTests[name]?
+      throw new Error("Cannot have more than one test with the name: #{name}")
+    @contentTests[name] = hook
 
   runBeforeAll: (callback) =>
     async.series @beforeAllHooks, (err, results) ->

--- a/src/test.coffee
+++ b/src/test.coffee
@@ -11,8 +11,8 @@ String::contains = (it) ->
   @indexOf(it) != -1
 
 class Test
-  constructor: () ->
-    @name = ''
+  constructor: (@name, @contentTest) ->
+    @name ?= ''
     @skip = false
 
     @request =
@@ -30,6 +30,9 @@ class Test
       headers: null
       body: null
 
+    @contentTest ?= (response, body, done) ->
+        done()
+
   url: () ->
     path = @request.server + @request.path
 
@@ -39,6 +42,7 @@ class Test
 
   run: (callback) ->
     assertResponse = @assertResponse
+    contentTest = @contentTest
 
     options = _.pick @request, 'headers', 'method'
     options['url'] = @url()
@@ -52,7 +56,7 @@ class Test
       ,
       (error, response, body, callback) ->
         assertResponse(error, response, body)
-        callback()
+        contentTest(response, body, callback)
     ], callback
 
   assertResponse: (error, response, body) =>
@@ -65,6 +69,7 @@ class Test
       #{body}
       Error
     """
+    response.status = response.statusCode
 
     # Body
     if @response.schema

--- a/test/unit/add-tests-test.coffee
+++ b/test/unit/add-tests-test.coffee
@@ -7,6 +7,7 @@ proxyquire = require('proxyquire').noCallThru()
 mochaStub = require 'mocha'
 
 Test = require '../../lib/test'
+hooks = require '../../lib/hooks'
 addTests = proxyquire '../../lib/add-tests', {
   'mocha': mochaStub
 }
@@ -21,13 +22,12 @@ describe '#addTests', ->
       callback = ''
 
       before (done) ->
-
         ramlParser.loadFile("#{__dirname}/../fixtures/single-get.raml")
         .then (data) ->
           callback = sinon.stub()
           callback.returns(done())
 
-          addTests data, tests, callback
+          addTests data, tests, hooks, callback
         , done
       after ->
         tests = []
@@ -74,7 +74,7 @@ describe '#addTests', ->
           callback = sinon.stub()
           callback.returns(done())
 
-          addTests data, tests, callback
+          addTests data, tests, hooks, callback
         , done
       after ->
         tests = []
@@ -120,7 +120,7 @@ describe '#addTests', ->
           callback = sinon.stub()
           callback.returns(done())
 
-          addTests data, tests, callback
+          addTests data, tests, hooks, callback
         , done
       after ->
         tests = []
@@ -163,7 +163,7 @@ describe '#addTests', ->
           callback = sinon.stub()
           callback.returns(done())
 
-          addTests data, tests, callback
+          addTests data, tests, hooks, callback
         , done
       after ->
         tests = []
@@ -206,7 +206,7 @@ describe '#addTests', ->
           callback = sinon.stub()
           callback.returns(done())
 
-          addTests data, tests, callback
+          addTests data, tests, hooks, callback
         , done
 
       after ->
@@ -245,7 +245,7 @@ describe '#addTests', ->
           callback = sinon.stub()
           callback.returns(done())
 
-          addTests data, tests, callback
+          addTests data, tests, hooks, callback
         , done
 
       after ->
@@ -288,7 +288,7 @@ describe '#addTests', ->
           callback.returns(done())
 
           sinon.stub console, 'warn'
-          addTests data, tests, callback
+          addTests data, tests, hooks, callback
         , done
 
       after ->

--- a/test/unit/hooks-test.coffee
+++ b/test/unit/hooks-test.coffee
@@ -338,3 +338,27 @@ describe 'Hooks', () ->
       it 'should run hook', ->
         assert.ok funcs[2].called
         assert.ok funcs[3].called
+
+  describe 'when successfully adding test hook', () ->
+
+    afterEach () ->
+      hooks.contentTests = {}
+
+    test_name = "content_test_test"
+
+    it 'should get added to the set of hooks', () ->
+      hooks.test(test_name, () ->)
+      assert.isDefined(hooks.contentTests[test_name])
+
+  describe 'adding two content tests fails', () ->
+    afterEach () ->
+      hooks.contentTests = {}
+
+    test_name = "content_test_test"
+
+    it 'should assert when adding a second content test', () ->
+      f = () ->
+        hooks.test(test_name, () ->)
+      f()
+      assert.throw f,
+        "Cannot have more than one test with the name: #{test_name}"

--- a/test/unit/test-test.coffee
+++ b/test/unit/test-test.coffee
@@ -26,9 +26,11 @@ describe 'Test', ->
 
       test = ''
       machine = ''
+      contentTestCalled = null
 
       before (done) ->
 
+        contentTestCalled = false
         test = new Test()
         test.name = 'POST /machines -> 201'
         test.request.server = 'http://abao.io'
@@ -48,6 +50,12 @@ describe 'Test', ->
         machine =
           type: 'foo'
           name: 'bar'
+
+        test.contentTest = (response, body, done) ->
+          contentTestCalled = true
+          assert.equal(response.status, 201)
+          assert.deepEqual(JSON.parse(body), machine)
+          return done()
 
         requestStub.callsArgWith(1, null, {statusCode: 201}, JSON.stringify(machine))
         test.run done
@@ -86,6 +94,9 @@ describe 'Test', ->
         # changed properties
         # assert.equal response.headers, 201
         assert.deepEqual response.body, machine
+
+      it 'should call contentTest', ->
+        assert.isTrue contentTestCalled
 
 
     describe 'of test contains params', ->


### PR DESCRIPTION
Abao does a great job of checking the form of the response. For my needs though, I needed to check the content as well. I could have duplicate sets of tests, one for checking the form (in abao) and another for checking the content (not in abao), but that seemed like a waste. I thought adding the ability to check the content within the test would be useful. I hope you agree!

I'm happy to rename the function from 'test' to 'contentTest' or something else similar if you think 'test' will be too confusing.