### PR TITLE
URL Wildcards for hook matching #67.

### DIFF
--- a/lib/hooks.coffee
+++ b/lib/hooks.coffee
@@ -1,5 +1,4 @@
 async = require 'async'
-_ = require 'underscore'
 
 class Hooks
   constructor: () ->
@@ -49,23 +48,30 @@ class Hooks
       callback(err)
 
   runBefore: (test, callback) =>
-    return callback() unless (@beforeHooks[test.name] or @beforeEachHooks)
+    beforeHook = @getMatchingHook @beforeHooks, test.name
+    return callback() unless (beforeHook or @beforeEachHooks)
 
-    hooks = @beforeEachHooks.concat(@beforeHooks[test.name] ? [])
+    hooks = @beforeEachHooks.concat(beforeHook ? [])
     async.eachSeries hooks, (hook, callback) ->
       hook test, callback
     , callback
 
   runAfter: (test, callback) =>
-    return callback() unless (@afterHooks[test.name] or @afterEachHooks)
+    afterHook = @getMatchingHook @afterHooks, test.name
+    return callback() unless (afterHook or @afterEachHooks)
 
-    hooks = (@afterHooks[test.name] ? []).concat(@afterEachHooks)
+    hooks = (afterHook ? []).concat(@afterEachHooks)
     async.eachSeries hooks, (hook, callback) ->
       hook test, callback
     , callback
 
   hasName: (name) =>
-    _.has(@beforeHooks, name) || _.has(@afterHooks, name)
+    (@getMatchingHook @beforeHooks, name) || (@getMatchingHook @afterHooks, name)
+
+  getMatchingHook: (hooks, name) =>
+    for key,value of hooks
+      if name.match key
+        return value
 
 
 module.exports = new Hooks()

--- a/test/unit/hooks-test.coffee
+++ b/test/unit/hooks-test.coffee
@@ -168,6 +168,14 @@ describe 'Hooks', () ->
 
       hooks.beforeHooks = {}
 
+    it 'should return true if test name matches regular expression hook', ->
+      hooks.beforeHooks =
+        'GET /.* -> [200|404]': (test, done) ->
+          done()
+
+      assert.ok hooks.hasName 'GET /users -> 200'
+      hooks.beforeHooks = {}
+
     it 'should return true if in after hooks', ->
       hooks.afterHooks =
         foo: (test, done) ->


### PR DESCRIPTION
We did a small extension to allow for wildcards in hook names. Not sure if it fits all your needs discussed in feature request #67.

Example to follow:
```
hooks.before('GET /.*/{id} -> 404', function (test, done) {
    test.request.params = {"id": "doesnotexist"};
    done();
});
```