### PR TITLE
Add Support for Node v4.2 in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,13 @@ deploy:
   on:
     tags: true
     repo: cybertk/abao
+matrix:
+  include:
+    - node_js: "4.2"
+      env: NODE_ENV=development CXX=g++-4.8
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8


### PR DESCRIPTION
We don't run test on 4.2 version. In this PR I added checking 4.2 version with correct CI flow in travis