### PR TITLE
Add Node version 6 check to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+- '6'
 - '5'
 - '4'
 - '0.12'


### PR DESCRIPTION
Current 6 Nodejs version soon will become LTS, so it would be good to start launching tests on it.
https://nodejs.org/en/blog/release/v6.0.0/