### PR TITLE
Throw error when invalid json is supplied for example

### DIFF
--- a/lib/add-tests.coffee
+++ b/lib/add-tests.coffee
@@ -84,7 +84,7 @@ addTests = (raml, tests, hooks, parent, callback, testFactory) ->
           try
             test.request.body = JSON.parse api.body[contentType]?.example
           catch
-            console.warn "cannot parse JSON example request body for #{test.name}"
+            throw new Error("cannot parse JSON example request body for #{test.name}")
         test.request.params = params
         test.request.query = query
 


### PR DESCRIPTION
This PR changes the default behavior from warning of an invalid example JSON to throwing an error