### PR TITLE
Add $ref support relative to CWD

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "request": "^2.53.0",
     "source-map-support": "^0.4.0",
     "tv4": "^1.2.7",
+    "json-schema-ref-parser": "^3.1.2",
     "underscore": "^1.8.2",
     "yargs": "~4.8.0"
   }

--- a/test/cli-test.coffee
+++ b/test/cli-test.coffee
@@ -60,7 +60,6 @@ describe 'Command line interface', ->
           execCommand "#{MOCHA_BIN} --reporters", ->
             reporters = stdout
             execCommand "#{ABAO_BIN} --reporters", done
-
         it 'exit status should be 0', () ->
           assert.equal exitStatus, 0
 
@@ -391,10 +390,10 @@ describe 'Command line interface', ->
           assert.include stdout, '0 passing'
 
       describe 'when invoked with "--schema" option', () ->
+
         before (done) ->
           ramlFile = "#{RAML_DIR}/with-json-refs.raml"
-          cmd = "#{ABAO_BIN} #{ramlFile} --server #{SERVER} --schemas=#{SCHEMA_DIR}/*.json"
-
+          cmd = "#{ABAO_BIN} #{ramlFile} --schemas=#{SCHEMA_DIR}/*.json --server #{SERVER}"
           app = express()
 
           app.get '/machines', (req, res) ->
@@ -410,7 +409,6 @@ describe 'Command line interface', ->
               server.close()
 
           server.on 'close', done
-
         it 'exit status should be 0', () ->
           assert.equal exitStatus, 0
 
@@ -437,4 +435,3 @@ describe 'Command line interface', ->
 
         it 'exit status should be 1', () ->
           assert.equal exitStatus, 1
-

--- a/test/fixtures/schemas/with-json-refs.json
+++ b/test/fixtures/schemas/with-json-refs.json
@@ -6,7 +6,7 @@
     {
       "type": "array",
       "items": {
-        "$ref": "http://example.api.com/jsonrefs/definitions#/definitions/machine"
+        "$ref": "test/fixtures/schemas/definitions.json#/definitions/machine"
       }
     }
   ],

--- a/test/unit/test-test.coffee
+++ b/test/unit/test-test.coffee
@@ -253,6 +253,7 @@ describe 'Test', ->
           type: 'string'
         name:
           type: 'string'}
+    test.response.expanded_schema = test.response.schema
 
     describe 'when against valid response', ->
 
@@ -288,4 +289,3 @@ describe 'Test', ->
         bodyStub = 'Im invalid'
         fn = _.partial test.assertResponse, errorStub, responseStub, bodyStub
         assert.throw fn, chai.AssertionError
-


### PR DESCRIPTION
This PR adds support for automatically resolving $ref's in jsonschema. 

URL $ref's are properly resolved, and relative file $ref's are resolved relative to the current working directory of the abao process.

Replaces PR #163

This does not properly resolve $ref's relative to the referring document, for that the RAML parser must pass the path of the schema file that was !included or the path to the RAML file for an inline schema.  That path needs to be fed to the $ref parser as the starting resolution scope.  In the future, the RAML parser could be updated to provide de-referencing as a feature so this functionality can work.  In the meantime, this PR allows projects using relative file paths in $ref's to work with abao, as is not currently possible with --schemas option.  The limitation is all $ref's which are relative $ref's must be relative to the working directory of abao.  In the future it would be easy to add a --schema-dir command line option to allow setting this directory, instead of changing where the abao command runs.  I still wanted to submit this PR because it is working and somewhat useful.  Thanks @plroebuck and @cybertk for your time on this issue and I look forward to your feedback!  
