### PR TITLE
Load file refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ Options:
                     running tests                                       [string]
   --schemas, -s     Specify a pattern to match schema files to be loaded for use
                     as JSON refs                                        [string]
+  --load-file-refs  For schema's containing $ref's which target the local
+                    filesystem, automatically expand those $ref's relative to
+                    the CWD of abao                                    [boolean]
   --reporter, -r    Specify the reporter to use       [string] [default: "spec"]
   --header, -h      Add header to include in each request. The header must be in
                     KEY:VALUE format, e.g. "-h Accept:application/json".
@@ -243,4 +246,3 @@ If you think of something that would make life easier, please submit an issue.
 [Travis]: https://travis-ci.org/
 [Jenkins]: https://jenkins-ci.org/
 [baseUri]: https://github.com/raml-org/raml-spec/blob/master/raml-0.8.md#base-uri-and-baseuriparameters
-

--- a/lib/abao.coffee
+++ b/lib/abao.coffee
@@ -23,7 +23,7 @@ class Abao
     hooks = @hooks
 
     # Inject the JSON refs schemas
-    factory = new TestFactory(config.options.schemas)
+    factory = new TestFactory(config.options.schemas, config.options['load-file-refs'])
 
     async.waterfall [
       # Parse hooks
@@ -53,4 +53,3 @@ class Abao
 
 module.exports = Abao
 module.exports.options = options
-

--- a/lib/options.coffee
+++ b/lib/options.coffee
@@ -13,6 +13,11 @@ options =
     description: 'Specify pattern to match schema files to be loaded for use as JSON refs'
     type: 'string'
 
+  'load-file-refs':
+    description: 'For schema\'s containing $ref\'s which target the local filesystem, ' +
+      'automatically expand those $ref\'s relative to the CWD of abao'
+    type: 'boolean'
+
   reporter:
     alias: 'r'
     description: 'Specify reporter to use'
@@ -65,4 +70,3 @@ options =
     type: 'boolean'
 
 module.exports = options
-

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "request": "^2.53.0",
     "source-map-support": "^0.4.0",
     "tv4": "^1.2.7",
+    "json-schema-ref-parser": "^3.1.2",
     "underscore": "^1.8.2",
     "yargs": "~4.8.0"
   }

--- a/test/cli-test.coffee
+++ b/test/cli-test.coffee
@@ -435,3 +435,50 @@ describe 'Command line interface', ->
 
         it 'exit status should be 1', () ->
           assert.equal exitStatus, 1
+
+      describe 'when invoked with "--load-file-refs" option', () ->
+
+        before (done) ->
+          ramlFile = "#{RAML_DIR}/with-file-refs.raml"
+          cmd = "#{ABAO_BIN} #{ramlFile} --load-file-refs --server #{SERVER}"
+          app = express()
+
+          app.get '/machines', (req, res) ->
+            res.setHeader 'Content-Type', 'application/json'
+            machine =
+              type: 'bulldozer'
+              name: 'willy'
+            response = [machine]
+            res.status(200).send response
+
+          server = app.listen PORT, () ->
+            execCommand cmd, () ->
+              server.close()
+
+          server.on 'close', done
+        it 'exit status should be 0', () ->
+          assert.equal exitStatus, 0
+
+      describe 'when invoked with "--load-file-refs" option and expecting error', () ->
+        before (done) ->
+          ramlFile = "#{RAML_DIR}/with-json-refs.raml"
+          cmd = "#{ABAO_BIN} #{ramlFile} --server #{SERVER} --load-file-refs"
+
+          app = express()
+
+          app.get '/machines', (req, res) ->
+            res.setHeader 'Content-Type', 'application/json'
+            machine =
+              typO: 'bulldozer'
+              name: 'willy'
+            response = [machine]
+            res.status(200).send response
+
+          server = app.listen PORT, () ->
+            execCommand cmd, () ->
+              server.close()
+
+          server.on 'close', done
+
+        it 'exit status should be 1', () ->
+          assert.equal exitStatus, 1

--- a/test/cli-test.coffee
+++ b/test/cli-test.coffee
@@ -60,7 +60,6 @@ describe 'Command line interface', ->
           execCommand "#{MOCHA_BIN} --reporters", ->
             reporters = stdout
             execCommand "#{ABAO_BIN} --reporters", done
-
         it 'exit status should be 0', () ->
           assert.equal exitStatus, 0
 
@@ -391,10 +390,10 @@ describe 'Command line interface', ->
           assert.include stdout, '0 passing'
 
       describe 'when invoked with "--schema" option', () ->
+
         before (done) ->
           ramlFile = "#{RAML_DIR}/with-json-refs.raml"
-          cmd = "#{ABAO_BIN} #{ramlFile} --server #{SERVER} --schemas=#{SCHEMA_DIR}/*.json"
-
+          cmd = "#{ABAO_BIN} #{ramlFile} --schemas=#{SCHEMA_DIR}/*.json --server #{SERVER}"
           app = express()
 
           app.get '/machines', (req, res) ->
@@ -410,7 +409,6 @@ describe 'Command line interface', ->
               server.close()
 
           server.on 'close', done
-
         it 'exit status should be 0', () ->
           assert.equal exitStatus, 0
 
@@ -437,4 +435,3 @@ describe 'Command line interface', ->
 
         it 'exit status should be 1', () ->
           assert.equal exitStatus, 1
-

--- a/test/fixtures/schemas/with-file-refs.json
+++ b/test/fixtures/schemas/with-file-refs.json
@@ -6,7 +6,7 @@
     {
       "type": "array",
       "items": {
-        "$ref": "http://example.api.com/jsonrefs/definitions#/definitions/machine"
+        "$ref": "test/fixtures/schemas/definitions.json#/definitions/machine"
       }
     }
   ],

--- a/test/fixtures/schemas/with-json-refs.json
+++ b/test/fixtures/schemas/with-json-refs.json
@@ -6,7 +6,7 @@
     {
       "type": "array",
       "items": {
-        "$ref": "http://example.api.com/jsonrefs/definitions#/definitions/machine"
+        "$ref": "test/fixtures/schemas/definitions.json#/definitions/machine"
       }
     }
   ],

--- a/test/fixtures/with-file-refs.raml
+++ b/test/fixtures/with-file-refs.raml
@@ -1,0 +1,20 @@
+#%RAML 0.8
+title: World Music API
+version: v1
+resourceTypes:
+  - resource:
+     get:
+       headers:
+         Abao-API-Key:
+           type: string
+           example: abcdef
+       description: Get <<resourcePathName|!singularize>> by Identifier
+       responses:
+         200:
+           body:
+             application/json:
+               schema: <<resourceSchema>>
+/machines:
+ type:
+   resource:
+     resourceSchema: !include schemas/with-file-refs.json

--- a/test/unit/test-test.coffee
+++ b/test/unit/test-test.coffee
@@ -253,6 +253,7 @@ describe 'Test', ->
           type: 'string'
         name:
           type: 'string'}
+    test.response.expanded_schema = test.response.schema
 
     describe 'when against valid response', ->
 
@@ -288,4 +289,3 @@ describe 'Test', ->
         bodyStub = 'Im invalid'
         fn = _.partial test.assertResponse, errorStub, responseStub, bodyStub
         assert.throw fn, chai.AssertionError
-


### PR DESCRIPTION
This PR adds support for automatically resolving file $ref's in jsonschema.

Relative file $ref's may optionally resolved relative to the current working directory of the abao process.  This behavior must be enabled by passing the --load-file-refs option

Replaces PR #163 and #165 

Copied from #165:

This does not properly resolve $ref's relative to the referring document, for that the RAML parser must pass the path of the schema file that was !included or the path to the RAML file for an inline schema. That path needs to be fed to the $ref parser as the starting resolution scope. In the future, the RAML parser could be updated to provide de-referencing as a feature so this functionality can work. In the meantime, this PR allows projects using relative file paths in $ref's to work with abao, as is not currently possible with --schemas option. The limitation is all $ref's which are relative $ref's must be relative to the working directory of abao.  

EDIT:  The new behavior is optional, disabled by default, and can be enabled with the --load-file-refs CLI option.  A test for this option was added and the old tests for --schemas left in place.   Thanks @plroebuck and @cybertk for your time on this issue and I look forward to your feedback!