### PR TITLE
🔧 Fix tests for Node.js 6.6

### DIFF
--- a/test/cli-test.coffee
+++ b/test/cli-test.coffee
@@ -41,9 +41,7 @@ execCommand = (cmd, callback) ->
     if error
       exitStatus = error.code
 
-  exitEventName = if process.version.split('.')[1] is '6' then 'exit' else 'close'
-
-  cli.on exitEventName, (code) ->
+  cli.on 'close', (code) ->
     exitStatus = code if exitStatus == null and code != undefined
     callback()
 


### PR DESCRIPTION
There were an old checking for Node.js v0.6.*, which brings down a build.
This pull request fixes this issue.