### PR TITLE
Implements ability to override endpoint ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,15 @@ Options:
                                                                        [boolean]
   --grep, -g        Only run tests matching <pattern>                   [string]
   --invert, -i      Invert --grep matches                              [boolean]
+  --sorted          Sorts requests in a sensible way so that objects are not
+                    modified before they are created. Order: CONNECT, OPTIONS,
+                    POST, GET, HEAD, PUT, PATCH, DELETE, TRACE.        [boolean]
   --timeout, -t     Set test-case timeout in milliseconds
                                                         [number] [default: 2000]
   --template        Specify the template file to use for generating hooks
-                                                                        [string]                                                      
+                                                                        [string]
   --names, -n       List names of requests and exit                    [boolean]
+  --generate-hooks  Output hooks generated from template file and exit [boolean]
   --reporters       Display available reporters and exit               [boolean]
   --help            Show usage information and exit                    [boolean]
   --version         Show version number and exit                       [boolean]

--- a/lib/abao.coffee
+++ b/lib/abao.coffee
@@ -42,7 +42,7 @@ class Abao
         if !config.options.server
           if raml.baseUri
             config.options.server = raml.baseUri
-        addTests raml, tests, hooks, callback, factory
+        addTests raml, tests, hooks, callback, factory, config.options.sorted
       ,
       # Run tests
       (callback) ->

--- a/lib/add-tests.coffee
+++ b/lib/add-tests.coffee
@@ -1,5 +1,5 @@
 async = require 'async'
-_ = require 'underscore'
+_ = require 'lodash'
 csonschema = require 'csonschema'
 
 
@@ -21,11 +21,11 @@ parseHeaders = (raml) ->
 
   headers
 
-# addTests(raml, tests, [parent], callback, config)
-addTests = (raml, tests, hooks, parent, callback, testFactory) ->
+addTests = (raml, tests, hooks, parent, callback, testFactory, sortFirst) ->
 
   # Handle 4th optional param
   if _.isFunction(parent)
+    sortFirst = testFactory
     testFactory = callback
     callback = parent
     parent = null
@@ -41,7 +41,7 @@ addTests = (raml, tests, hooks, parent, callback, testFactory) ->
     # Apply parent properties
     if parent
       path = parent.path + path
-      params = _.clone parent.params
+      params = _.clone parent.params      # shallow copy
 
     # Setup param
     if resource.uriParameters
@@ -51,6 +51,49 @@ addTests = (raml, tests, hooks, parent, callback, testFactory) ->
 
     # In case of issue #8, resource does not define methods
     resource.methods ?= []
+
+    if sortFirst && resource.methods.length > 1
+      methodTests = [
+          method: 'CONNECT', tests: []
+        ,
+          method: 'OPTIONS', tests: []
+        ,
+          method: 'POST',    tests: []
+        ,
+          method: 'GET',     tests: []
+        ,
+          method: 'HEAD',    tests: []
+        ,
+          method: 'PUT',     tests: []
+        ,
+          method: 'PATCH',   tests: []
+        ,
+          method: 'DELETE',  tests: []
+        ,
+          method: 'TRACE',   tests: []
+      ]
+
+      # Group endpoint tests by method name
+      _.each methodTests, (methodTest) ->
+        isSameMethod = (test) ->
+          return methodTest.method == test.method.toUpperCase()
+
+        ans = _.partition resource.methods, isSameMethod
+        if ans[0].length != 0
+          _.each ans[0], (test) -> methodTest.tests.push test
+          resource.methods = ans[1]
+
+      # Shouldn't happen unless new HTTP method introduced...
+      leftovers = resource.methods
+      if leftovers.length > 1
+        console.error 'unknown method calls present!', leftovers
+
+      # Now put them back, but in order of methods listed above
+      sortedTests = _.map methodTests, (methodTest) -> return methodTest.tests
+      leftoverTests = _.map leftovers, (leftover) -> return leftover
+      reassembled = _.flattenDeep [_.reject sortedTests,   _.isEmpty,
+                                   _.reject leftoverTests, _.isEmpty]
+      resource.methods = reassembled
 
     # Iterate response method
     async.each resource.methods, (api, callback) ->
@@ -108,7 +151,7 @@ addTests = (raml, tests, hooks, parent, callback, testFactory) ->
       return callback(err) if err
 
       # Recursive
-      addTests resource, tests, hooks, {path, params}, callback, testFactory
+      addTests resource, tests, hooks, {path, params}, callback, testFactory, sortFirst
   , callback
 
 

--- a/lib/apply-configuration.coffee
+++ b/lib/apply-configuration.coffee
@@ -33,6 +33,7 @@ applyConfiguration = (config) ->
       grep: ''
       invert: false
       'hooks-only': false
+      sorted: false
 
   # Normalize options and config
   for own key, value of config

--- a/lib/options.coffee
+++ b/lib/options.coffee
@@ -40,6 +40,12 @@ options =
     description: 'Invert --grep matches'
     type: 'boolean'
 
+  sorted:
+    description: 'Sorts requests in a sensible way so that objects are not ' +
+                 'modified before they are created.\nOrder: ' +
+                 'CONNECT, OPTIONS, POST, GET, HEAD, PUT, PATCH, DELETE, TRACE.'
+    type: 'boolean'
+
   timeout:
     alias: 't'
     description: 'Set test-case timeout in milliseconds'

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "source-map-support": "^0.4.0",
     "tv4": "^1.2.7",
     "underscore": "^1.8.2",
+    "lodash": "^4.16.4",
     "yargs": "~6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abao",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "RAML testing tool",
   "bin": "bin/abao",
   "main": "lib/index.js",


### PR DESCRIPTION
Implements `--sorted` cmdline option (like Dredd).

Sorts endpoint requests in a sensible way so that objects are not modified before they are created.

Order: CONNECT, OPTIONS, POST, GET, HEAD, PUT, PATCH, DELETE, TRACE.

Closes: #22